### PR TITLE
Add instructions to get equations-parser submodule

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,6 +38,8 @@ libs.each do |lib|
 end
 
 Dir.chdir(BASEDIR) do
+  system('git init')
+  system('git submodule add https://github.com/niltonvasques/equations-parser.git ext/equations-parser')
   system('git submodule update --init --recursive')
 
   Dir.chdir('ext/equations-parser/') do


### PR DESCRIPTION
Before updating the equations-parser submodule, it is necessary to make the gem repository a git repository and define the git submodule path.