### PR TITLE
A try to debug the directories

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -15,8 +15,19 @@ MUPARSER_LIB = "#{BASEDIR}/ext/equations-parser".freeze
 
 HEADER_DIRS = [INCLUDEDIR, MUPARSER_HEADERS].freeze
 
-puts HEADER_DIRS
-puts LIBDIR
+puts '#'*90
+puts 'LIBDIR: ' << LIBDIR.to_s
+puts '#'*90
+puts 'HEADER_DIRS: ' << HEADER_DIRS.to_s
+puts '#'*90
+puts 'MUPARSER_LIB: ' << HEADER_DIRS.to_s
+puts '#'*90
+puts '#'*20 << ' -- 1st pwd -- ' << '#'*20
+puts Dir.pwd
+puts '#'*90
+puts '#'*20 << ' -- 1st ls -- ' << '#'*20
+puts Dir.entries('.')
+puts '#'*90
 
 # setup constant that is equal to that of the file path that holds
 # that static libraries that will need to be compiled against
@@ -43,8 +54,24 @@ Dir.chdir(BASEDIR) do
   system('git submodule update --init --recursive')
 
   Dir.chdir('ext/equations-parser/') do
-    system('cmake CMakeLists.txt -DCMAKE_BUILD_TYPE=Release')
-    system('make')
+    puts '#'*90
+    puts '#'*20 << ' -- 2nd pwd -- ' << '#'*20
+    puts Dir.pwd
+    puts '#'*90
+    puts '#'*20 << ' -- 2nd ls -- ' << '#'*20
+    puts Dir.entries('.')
+    puts '#'*90
+
+    # system('cmake CMakeLists.txt -DCMAKE_BUILD_TYPE=Release')
+    # system('make')
+
+    puts '#'*90
+    puts '#'*20 << ' -- cmake (C++ muparserx) -- ' << '#'*20
+    puts `cmake CMakeLists.txt -DCMAKE_BUILD_TYPE=Release`
+    puts '#'*90
+    puts '#'*20 << ' -- make (C++ muparserx) -- ' << '#'*20
+    puts `make`
+    puts '#'*90
   end
 
   Dir.chdir('ext/libnativemath/') do
@@ -64,6 +91,13 @@ create_makefile('ext/libnativemath/libnativemath')
 
 Dir.chdir(BASEDIR) do
   Dir.chdir('ext/libnativemath/') do
-    system('make')
+    # system('make')
+
+    puts '#'*90
+    puts '#'*20 << ' -- make (Swig) -- ' << '#'*20
+    puts `make`
+    puts '#'*90
+    abort 'ABORTED HERE'
+    puts '#'*90
   end
 end

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']
-  s.description           = 'ParseCs is a gem to evaluate equations using a lighter and extented version of the muparserx C++ library'
+  s.description           = 'ParseCs is a gem to evaluate equations using a lighter and extended version of the muparserx C++ library'
   s.homepage              = 'https://github.com/niltonvasques/parsec'
   s.summary               = 'A gem to evaluate equations using muparserx C++ library'
   s.files                 = ['lib/parsec.rb', 'lib/string_to_boolean_refinements.rb', 'ext/libnativemath/libnativemath.i',


### PR DESCRIPTION
# DO NOT MERGE THIS!
## THIS PR IS JUST FOR DEBUG PURPOSES

@beatrizfagundes and/or @niltonvasques 
Can you try to add the debug lines of this PR and give me the console output?
I'll compare with the output of my computer.

The current version of this `gem` is working on @beatrizfagundes 's pc. It is installing correctly there. However, it is not working on my computer... Somehow, the `Parsec::Parsec` class is not created, just the `Parsec` module, as you can see on the below picture...

![screen shot 2018-05-27 at 19 33 13](https://user-images.githubusercontent.com/7637806/40591289-e7985248-61e4-11e8-9135-409aef52e109.png)


# Please, execute
```
gem build parsec.gemspec
gem install parsecs-0.2.16.gem
```

# And give me the console output :D 

My output is
```
victorcosta@Victors-MacBook-Air-2:~/Desktop/parsec((HEAD detached from 585ddea)**) $ gem build parsec.gemspec
  Successfully built RubyGem
  Name: parsecs
  Version: 0.2.16
  File: parsecs-0.2.16.gem
victorcosta@Victors-MacBook-Air-2:~/Desktop/parsec((HEAD detached from 585ddea)**) $ gem install parsecs-0.2.16.gem
Building native extensions. This could take a while...
ERROR:  Error installing parsecs-0.2.16.gem:
	ERROR: Failed to build gem native extension.

    current directory: /Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/ext/libnativemath
/Users/victorcosta/.rvm/rubies/ruby-2.5.0/bin/ruby -r ./siteconf20180527-63332-uu537m.rb extconf.rb
##########################################################################################
LIBDIR: /Users/victorcosta/.rvm/rubies/ruby-2.5.0/lib
##########################################################################################
HEADER_DIRS: ["/Users/victorcosta/.rvm/rubies/ruby-2.5.0/include", "../../ext/equations-parser/parser"]
##########################################################################################
MUPARSER_LIB: ["/Users/victorcosta/.rvm/rubies/ruby-2.5.0/include", "../../ext/equations-parser/parser"]
##########################################################################################
#################### -- 1st pwd -- ####################
/Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/ext/libnativemath
##########################################################################################
#################### -- 1st ls -- ####################
.
..
siteconf20180527-63332-uu537m.rb
libnativemath.cpp
libnativemath.h
libnativemath.i
extconf.rb
.gem.20180527-63332-1ce18wl
##########################################################################################
checking for cmake... yes
checking for swig... yes
Initialized empty Git repository in /Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/.git/
Cloning into '/Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/ext/equations-parser'...
##########################################################################################
#################### -- 2nd pwd -- ####################
/Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/ext/equations-parser
##########################################################################################
#################### -- 2nd ls -- ####################
.
..
CMakeLists.txt
cmake
Makefile
parser
muparserx.in.pc
.gitignore
sample
doc
Readme.txt
build
.git
License.txt
value_test
##########################################################################################
##########################################################################################
#################### -- cmake (C++ muparserx) -- ####################
-- The CXX compiler identification is AppleClang 9.1.0.9020039
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test HAS_STD_CXX11
-- Performing Test HAS_STD_CXX11 - Success
-- Building muparserx version: 4.0.7
-- Using install prefix: /usr/local
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/ext/equations-parser
##########################################################################################
#################### -- make (C++ muparserx) -- ####################
/Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/ext/equations-parser/parser/mpOprtPostfixCommon.cpp:43:15: warning: unknown pragma ignored [-Wunknown-pragmas]
      #pragma warning(push)
              ^
/Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/ext/equations-parser/parser/mpOprtPostfixCommon.cpp:44:15: warning: unknown pragma ignored [-Wunknown-pragmas]
      #pragma warning(disable:4127)
              ^
/Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16/ext/equations-parser/parser/mpOprtPostfixCommon.cpp:47:15: warning: unknown pragma ignored [-Wunknown-pragmas]
      #pragma warning(pop)
              ^
3 warnings generated.
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: libmuparserx.a(mpTest.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: libmuparserx.a(mpTest.cpp.o) has no symbols
Scanning dependencies of target muparserx
[  2%] Building CXX object CMakeFiles/muparserx.dir/parser/mpError.cpp.o
[  4%] Building CXX object CMakeFiles/muparserx.dir/parser/mpFuncCmplx.cpp.o
[  7%] Building CXX object CMakeFiles/muparserx.dir/parser/mpFuncCommon.cpp.o
[  9%] Building CXX object CMakeFiles/muparserx.dir/parser/mpFuncMatrix.cpp.o
[ 12%] Building CXX object CMakeFiles/muparserx.dir/parser/mpFuncNonCmplx.cpp.o
[ 14%] Building CXX object CMakeFiles/muparserx.dir/parser/mpFuncStr.cpp.o
[ 17%] Building CXX object CMakeFiles/muparserx.dir/parser/mpICallback.cpp.o
[ 19%] Building CXX object CMakeFiles/muparserx.dir/parser/mpIOprt.cpp.o
[ 21%] Building CXX object CMakeFiles/muparserx.dir/parser/mpIPackage.cpp.o
[ 24%] Building CXX object CMakeFiles/muparserx.dir/parser/mpIToken.cpp.o
[ 26%] Building CXX object CMakeFiles/muparserx.dir/parser/mpIValReader.cpp.o
[ 29%] Building CXX object CMakeFiles/muparserx.dir/parser/mpIValue.cpp.o
[ 31%] Building CXX object CMakeFiles/muparserx.dir/parser/mpIfThenElse.cpp.o
[ 34%] Building CXX object CMakeFiles/muparserx.dir/parser/mpOprtBinAssign.cpp.o
[ 36%] Building CXX object CMakeFiles/muparserx.dir/parser/mpOprtBinCommon.cpp.o
[ 39%] Building CXX object CMakeFiles/muparserx.dir/parser/mpOprtCmplx.cpp.o
[ 41%] Building CXX object CMakeFiles/muparserx.dir/parser/mpOprtIndex.cpp.o
[ 43%] Building CXX object CMakeFiles/muparserx.dir/parser/mpOprtMatrix.cpp.o
[ 46%] Building CXX object CMakeFiles/muparserx.dir/parser/mpOprtNonCmplx.cpp.o
[ 48%] Building CXX object CMakeFiles/muparserx.dir/parser/mpOprtPostfixCommon.cpp.o
[ 51%] Building CXX object CMakeFiles/muparserx.dir/parser/mpPackageCmplx.cpp.o
[ 53%] Building CXX object CMakeFiles/muparserx.dir/parser/mpPackageCommon.cpp.o
[ 56%] Building CXX object CMakeFiles/muparserx.dir/parser/mpPackageMatrix.cpp.o
[ 58%] Building CXX object CMakeFiles/muparserx.dir/parser/mpPackageNonCmplx.cpp.o
[ 60%] Building CXX object CMakeFiles/muparserx.dir/parser/mpPackageStr.cpp.o
[ 63%] Building CXX object CMakeFiles/muparserx.dir/parser/mpPackageUnit.cpp.o
[ 65%] Building CXX object CMakeFiles/muparserx.dir/parser/mpParser.cpp.o
[ 68%] Building CXX object CMakeFiles/muparserx.dir/parser/mpParserBase.cpp.o
[ 70%] Building CXX object CMakeFiles/muparserx.dir/parser/mpParserMessageProvider.cpp.o
[ 73%] Building CXX object CMakeFiles/muparserx.dir/parser/mpRPN.cpp.o
[ 75%] Building CXX object CMakeFiles/muparserx.dir/parser/mpScriptTokens.cpp.o
[ 78%] Building CXX object CMakeFiles/muparserx.dir/parser/mpTest.cpp.o
[ 80%] Building CXX object CMakeFiles/muparserx.dir/parser/mpTokenReader.cpp.o
[ 82%] Building CXX object CMakeFiles/muparserx.dir/parser/mpValReader.cpp.o
[ 85%] Building CXX object CMakeFiles/muparserx.dir/parser/mpValue.cpp.o
[ 87%] Building CXX object CMakeFiles/muparserx.dir/parser/mpValueCache.cpp.o
[ 90%] Building CXX object CMakeFiles/muparserx.dir/parser/mpVariable.cpp.o
[ 92%] Linking CXX static library libmuparserx.a
[ 92%] Built target muparserx
Scanning dependencies of target example
[ 95%] Building CXX object CMakeFiles/example.dir/sample/example.cpp.o
[ 97%] Building CXX object CMakeFiles/example.dir/sample/timer.cpp.o
[100%] Linking CXX executable example
[100%] Built target example
##########################################################################################
creating Makefile
##########################################################################################
#################### -- make (Swig) -- ####################
In file included from libnativemath.cpp:4:
In file included from ../../ext/equations-parser/parser/mpParser.h:41:
In file included from ../../ext/equations-parser/parser/mpParserBase.h:45:
In file included from ../../ext/equations-parser/parser/mpIOprt.h:42:
In file included from ../../ext/equations-parser/parser/mpICallback.h:43:
In file included from ../../ext/equations-parser/parser/mpIToken.h:41:
In file included from ../../ext/equations-parser/parser/mpTypes.h:50:
../../ext/equations-parser/parser/mpCompat.h:50:11: warning: 'nullptr' macro redefined [-Wmacro-redefined]
  #define nullptr NULL
          ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/__nullptr:49:9: note: previous definition is here
#define nullptr _VSTD::__get_nullptr_t()
        ^
1 warning generated.
ABORTED HERE
compiling libnativemath.cpp
compiling libnativemath_wrap.cxx
linking shared-object ext/libnativemath/libnativemath.bundle
##########################################################################################

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /Users/victorcosta/.rvm/gems/ruby-2.5.0/extensions/x86_64-darwin-17/2.5.0/parsecs-0.2.16/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /Users/victorcosta/.rvm/gems/ruby-2.5.0/gems/parsecs-0.2.16 for inspection.
Results logged to /Users/victorcosta/.rvm/gems/ruby-2.5.0/extensions/x86_64-darwin-17/2.5.0/parsecs-0.2.16/gem_make.out
```

The `parsec` itself is working locally here, but it doesn't work via installing the gem.
You can check it is really working locally here by the below picture...
![screen shot 2018-05-27 at 19 39 28](https://user-images.githubusercontent.com/7637806/40591338-d428d592-61e5-11e8-879b-fd44a80be612.png)
