### PR TITLE
Fix two quotations bug

### DIFF
--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -58,7 +58,7 @@ module Parsec
 
     def self.error_check(output)
       raise SyntaxError, output.sub(/^Error: /, '') if output.match?(/^Error:/)
-      output.delete('\"')
+      output
     end
 
     def self.validate(ans, raise_error)

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -57,14 +57,14 @@ module Parsec
     end
 
     def self.error_check(output)
-      raise SyntaxError, output.sub('Error: ', '') if output.include?('Error')
+      raise SyntaxError, output.sub(/^Error: /, '') if output.match?(/^Error:/)
       output.delete('\"')
     end
 
     def self.validate(ans, raise_error)
-      if (ans['type'] == 'string') && ans['value'].include?('Error: ')
-        raise SyntaxError, ans['value'].sub('Error: ', '') if raise_error
-        return ans['value'].sub('Error: ', '')
+      if (ans['type'] == 'string') && ans['value'].match?(/^Error:/)
+        raise SyntaxError, ans['value'].sub(/^Error: /, '') if raise_error
+        return ans['value'].sub(/^Error: /, '')
       end
       true
     end

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -63,6 +63,7 @@ class TestParsec < Minitest::Test
 
   def test_complex_string_manipulation
     parser = Parsec::Parsec
+    assert_equal('string with quote\"', parser.eval_equation('"string with quote\""'))
     assert_equal('HELLO WORLD', parser.eval_equation('toupper(concat("hello ", "world"))'))
     assert_equal('test lowercase', parser.eval_equation('tolower("TEST LOWERCASE")'))
     assert_equal('Hello', parser.eval_equation('left("Hello World", 5)'))


### PR DESCRIPTION
- [x] Maintain the skipped two quotations inside the string
- [x] Better match the Error string

This PR fixes the bug related to the `"` remotion if the string has `"` inside it 👍 

# Before
![before](https://user-images.githubusercontent.com/7637806/52514064-862f4880-2bed-11e9-941d-2967f553cd8b.png)

# After
![after](https://user-images.githubusercontent.com/7637806/52514066-89c2cf80-2bed-11e9-9afb-d3e7d62f4ae6.png)
