### PR TITLE
Create the method eval_equation_with_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ gem 'parsecs'
 ## Tests
 
 ```ruby
+gem build parsec.gemspec
+gem install ./parsecs-VERSION.gem (e.g.: gem install ./parsecs-0.5.1.gem)
 ruby -Ilib -Iext/libnativemath test/test_parsec.rb
 ```
 

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -38,7 +38,7 @@ module Parsec
       remove(equation, true)
 
       result = Libnativemath.native_eval(equation)
-      result['type'].to_sym
+      result['type'].to_sym if validate(result, true)
     end
 
     private_class_method

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -8,16 +8,17 @@ module Parsec
 
     VERSION = '0.5.1'.freeze
 
-    # define an instance class variable to store the result type of the last evaluated equation
-    class <<self
-      attr_accessor :last_result_type
+    # evaluates the equation and returns only the result
+    def self.eval_equation(equation)
+      eval_equation_with_type(equation)[:value]
     end
 
-    # evaluates the equation
-    def self.eval_equation(equation)
+    # evaluates the equation and returns the result and its data type
+    def self.eval_equation_with_type(equation)
       remove(equation, true)
 
-      convert(Libnativemath.native_eval(equation))
+      result = Libnativemath.native_eval(equation)
+      { value: convert(result), type: result['type'].to_sym }
     end
 
     # returns true or raise an error
@@ -57,8 +58,6 @@ module Parsec
       when '-inf' then return '-Infinity'
       when 'nan' then return ans['value']
       end
-
-      self.last_result_type = ans['type'].to_sym
 
       case ans['type']
       when 'int'     then return ans['value'].to_i

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -29,6 +29,13 @@ module Parsec
       validate(Libnativemath.native_eval(equation), false)
     end
 
+    def self.get_result_type(equation)
+      remove(equation, true)
+
+      result = Libnativemath.native_eval(equation)
+      result['type'].to_sym
+    end
+
     private_class_method
 
     def self.remove(equation, new_line = false)

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.4.1'.freeze
+    VERSION = '0.5.1'.freeze
 
     # evaluates the equation
     def self.eval_equation(equation)

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -8,7 +8,7 @@ module Parsec
 
     VERSION = '0.5.1'.freeze
 
-    # define an instance class variable to return the result type of the last equation evaluated
+    # define an instance class variable to store the result type of the last evaluated equation
     class <<self
       attr_accessor :last_result_type
     end

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -8,6 +8,11 @@ module Parsec
 
     VERSION = '0.5.1'.freeze
 
+    # define an instance class variable to return the result type of the last equation evaluated
+    class <<self
+      attr_accessor :last_result_type
+    end
+
     # evaluates the equation
     def self.eval_equation(equation)
       remove(equation, true)
@@ -52,6 +57,8 @@ module Parsec
       when '-inf' then return '-Infinity'
       when 'nan' then return ans['value']
       end
+
+      self.last_result_type = ans['type'].to_sym
 
       case ans['type']
       when 'int'     then return ans['value'].to_i

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.4.1'
+  s.version               = '0.5.1'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -123,10 +123,23 @@ class TestParsec < Minitest::Test
     assert_equal(:int, parsec.get_result_type('10!'))
     assert_equal(:int, parsec.get_result_type('daysdiff("2018-01-01", "2017-12-31")'))
     assert_equal(:float, parsec.get_result_type('log10(10) + ln(e) + log(10)'))
+    assert_equal(:float, parsec.get_result_type('number("5.1")'))
     assert_equal(:string, parsec.get_result_type('4 > 2 ? "bigger" : "smaller"'))
     assert_equal(:string, parsec.get_result_type('string(5.123)'))
     assert_equal(:boolean, parsec.get_result_type('2 == 2 ? true : false'))
     assert_equal(:boolean, parsec.get_result_type('2 != 2 ? true : false'))
     assert_equal(:boolean, parsec.get_result_type('(3==3) and (3!=3)'))
+  end
+
+  def test_last_result_type
+    parsec = Parsec::Parsec
+    parsec.eval_equation('(5 + 1) + (6 - 2)')
+    assert_equal(:int, parsec.last_result_type)
+    parsec.eval_equation('number("5.1")')
+    assert_equal(:float, parsec.last_result_type)
+    parsec.eval_equation('string(5.123)')
+    assert_equal(:string, parsec.last_result_type)
+    parsec.eval_equation('(3==3) and (3!=3)')
+    assert_equal(:boolean, parsec.last_result_type)
   end
 end

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -95,6 +95,12 @@ class TestParsec < Minitest::Test
     assert_equal(true, parsec.validate_syntax("\n4\n+ \n 2\n"))
   end
 
+  def test_equation_with_bad_syntax
+    parsec = Parsec::Parsec
+    assert_raises(SyntaxError) { parsec.eval_equation('concat(1, 2)') }
+    assert_raises(SyntaxError) { parsec.eval_equation('4 > 2 ? "smaller"') }
+  end
+
   def test_validate_syntax
     parsec = Parsec::Parsec
     refute_equal(true, parsec.validate_syntax('((0.09/1.0)+2.58)-1.6+'))
@@ -117,34 +123,25 @@ class TestParsec < Minitest::Test
     assert_equal(1, parsec.eval_equation('daysdiff("2018-01-01", "2017-12-31")'))
   end
 
-  def test_get_result_type
+  def test_eval_equation_with_type
     parsec = Parsec::Parsec
-    assert_equal(:int, parsec.get_result_type('(5 + 1) + (6 - 2)'))
-    assert_equal(:int, parsec.get_result_type('10!'))
-    assert_equal(:int, parsec.get_result_type('daysdiff("2018-01-01", "2017-12-31")'))
-    assert_equal(:float, parsec.get_result_type('log10(10) + ln(e) + log(10)'))
-    assert_equal(:float, parsec.get_result_type('number("5.1")'))
-    assert_equal(:string, parsec.get_result_type('4 > 2 ? "bigger" : "smaller"'))
-    assert_equal(:string, parsec.get_result_type('string(5.123)'))
-    assert_equal(:boolean, parsec.get_result_type('2 == 2 ? true : false'))
-    assert_equal(:boolean, parsec.get_result_type('2 != 2 ? true : false'))
-    assert_equal(:boolean, parsec.get_result_type('(3==3) and (3!=3)'))
-    assert_equal(:float, parsec.get_result_type('4 / 0'))
-    assert_equal(:float, parsec.get_result_type('0 / 0'))
+    assert_equal({ value: 10, type: :int }, parsec.eval_equation_with_type('(5 + 1) + (6 - 2)'))
+    assert_equal({ value: 362_880_0, type: :int }, parsec.eval_equation_with_type('10!'))
+    equation_date = 'daysdiff("2018-01-01", "2017-12-31")'
+    assert_equal({ value: 1, type: :int }, parsec.eval_equation_with_type(equation_date))
+    assert_equal({ value: 40.6853, type: :float }, parsec.eval_equation_with_type('10^log(3+2)'))
+    assert_equal({ value: 5.1, type: :float }, parsec.eval_equation_with_type('number("5.1")'))
+    equation_if = '4 > 2 ? "bigger" : "smaller"'
+    assert_equal({ value: "bigger", type: :string }, parsec.eval_equation_with_type(equation_if))
+    assert_equal({ value: "5.123", type: :string }, parsec.eval_equation_with_type('string(5.123)'))
+    equation_boolean = '2 == 2 ? true : false'
+    assert_equal({ value: true, type: :boolean }, parsec.eval_equation_with_type(equation_boolean))
+    equation_boolean = '(3==3) and (3!=3)'
+    assert_equal({ value: false, type: :boolean }, parsec.eval_equation_with_type(equation_boolean))
+    assert_equal({ value: 'Infinity', type: :float }, parsec.eval_equation_with_type('4 / 0'))
+    assert_equal({ value: 'nan', type: :float }, parsec.eval_equation_with_type('0 / 0'))
     # invalid equations raises an error
-    assert_raises(SyntaxError) { parsec.get_result_type('concat(1, 2)') }
-    assert_raises(SyntaxError) { parsec.get_result_type('4 > 2 ? "smaller"') }
-  end
-
-  def test_last_result_type
-    parsec = Parsec::Parsec
-    parsec.eval_equation('(5 + 1) + (6 - 2)')
-    assert_equal(:int, parsec.last_result_type)
-    parsec.eval_equation('number("5.1")')
-    assert_equal(:float, parsec.last_result_type)
-    parsec.eval_equation('string(5.123)')
-    assert_equal(:string, parsec.last_result_type)
-    parsec.eval_equation('(3==3) and (3!=3)')
-    assert_equal(:boolean, parsec.last_result_type)
+    assert_raises(SyntaxError) { parsec.eval_equation_with_type('concat(1, 2)') }
+    assert_raises(SyntaxError) { parsec.eval_equation_with_type('4 > 2 ? "smaller"') }
   end
 end

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -129,6 +129,11 @@ class TestParsec < Minitest::Test
     assert_equal(:boolean, parsec.get_result_type('2 == 2 ? true : false'))
     assert_equal(:boolean, parsec.get_result_type('2 != 2 ? true : false'))
     assert_equal(:boolean, parsec.get_result_type('(3==3) and (3!=3)'))
+    assert_equal(:float, parsec.get_result_type('4 / 0'))
+    assert_equal(:float, parsec.get_result_type('0 / 0'))
+    # invalid equations raises an error
+    assert_raises(SyntaxError) { parsec.get_result_type('concat(1, 2)') }
+    assert_raises(SyntaxError) { parsec.get_result_type('4 > 2 ? "smaller"') }
   end
 
   def test_last_result_type

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -116,4 +116,17 @@ class TestParsec < Minitest::Test
     assert_equal(364, parsec.eval_equation('daysdiff("2100-01-01", "2100-12-31")'))
     assert_equal(1, parsec.eval_equation('daysdiff("2018-01-01", "2017-12-31")'))
   end
+
+  def test_get_result_type
+    parsec = Parsec::Parsec
+    assert_equal(:int, parsec.get_result_type('(5 + 1) + (6 - 2)'))
+    assert_equal(:int, parsec.get_result_type('10!'))
+    assert_equal(:int, parsec.get_result_type('daysdiff("2018-01-01", "2017-12-31")'))
+    assert_equal(:float, parsec.get_result_type('log10(10) + ln(e) + log(10)'))
+    assert_equal(:string, parsec.get_result_type('4 > 2 ? "bigger" : "smaller"'))
+    assert_equal(:string, parsec.get_result_type('string(5.123)'))
+    assert_equal(:boolean, parsec.get_result_type('2 == 2 ? true : false'))
+    assert_equal(:boolean, parsec.get_result_type('2 != 2 ? true : false'))
+    assert_equal(:boolean, parsec.get_result_type('(3==3) and (3!=3)'))
+  end
 end


### PR DESCRIPTION
- [x] Create method `Parsec.eval_equation_with_type(equation)` to evaluate an equation and return its result along with the result type (int, float, boolean, string, etc) 

- [x] Add to README required steps to run tests