### PR TITLE
Add hoursdiff date or datetime validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ gem 'parsecs'
 
 ```ruby
 gem build parsec.gemspec
-gem install ./parsecs-VERSION.gem (e.g.: gem install ./parsecs-0.5.1.gem)
+gem install ./parsecs-VERSION.gem (e.g.: gem install ./parsecs-0.6.2.gem)
 ruby -Ilib -Iext/libnativemath test/test_parsec.rb
 ```
 

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/niltonvasques/equations-parser.git'.freeze
-COMMIT = '65ff99e53961d86f14d214e49154ae26c94ec221'.freeze
+COMMIT = 'eae00acfc8c4ea9fb7ff16dff11e51bdd260035f'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.5.1'.freeze
+    VERSION = '0.6.2'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.5.1'
+  s.version               = '0.6.2'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -136,6 +136,8 @@ class TestParsec < Minitest::Test
     assert_raises(SyntaxError) { parsec.eval_equation('hoursdiff("INVALID1", "2018-01-01")') }
     assert_raises(SyntaxError) { parsec.eval_equation('hoursdiff("INVALID1", "INVALID2")') }
     assert_raises(SyntaxError) { parsec.eval_equation('hoursdiff(2, 3)') }
+    assert_raises(SyntaxError) { parsec.eval_equation('hoursdiff("2018-01-01", "2018-01-01T12:00")') }
+    assert_raises(SyntaxError) { parsec.eval_equation('hoursdiff("2018-01-01T12:00", "2018-01-01")') }
   end
 
   def test_eval_equation_with_type


### PR DESCRIPTION
- [x] Add a validation on `hoursdiff()` function at `c++` level where there can be only exactly **two dates** or **two datetimes** on `hoursdiff()` parameters. (https://github.com/niltonvasques/equations-parser/pull/23)
- [x] Add tests
- [x] Update Parsec version