### PR TITLE
Fix default_value() numbers incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ gem 'parsecs'
 
 ```ruby
 gem build parsec.gemspec
-gem install ./parsecs-VERSION.gem (e.g.: gem install ./parsecs-0.8.0.gem)
+gem install ./parsecs-VERSION.gem (e.g.: gem install ./parsecs-0.8.1.gem)
 ruby -Ilib -Iext/libnativemath test/test_parsec.rb
 ```
 

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/niltonvasques/equations-parser.git'.freeze
-COMMIT = 'eca316d8ad99d4f2e68539a1efd7524288817006'.freeze
+COMMIT = 'f83b631eff678b9c6bf1c2d31e524c1b587cb048'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.8.0'.freeze
+    VERSION = '0.8.1'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.8.0'
+  s.version               = '0.8.1'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -202,8 +202,17 @@ class TestParsec < Minitest::Test
     assert_equal(false, parsec.eval_equation('default_value(false, true)'))
     assert_equal(true, parsec.eval_equation('default_value(NULL, true)'))
 
+    # Mixing number types
+    assert_equal(1, parsec.eval_equation('default_value(1, 4.5)'))
+    assert_equal(1, parsec.eval_equation('default_value(1, 10)'))
+    assert_equal(1, parsec.eval_equation('default_value(1, 10.0)'))
+    assert_equal(1, parsec.eval_equation('default_value(1.0, 10)'))
+    assert_equal(1, parsec.eval_equation('default_value(1.0, 10.0)'))
+    assert_equal(1.5, parsec.eval_equation('default_value(1.5, 10)'))
+    assert_equal(1.5, parsec.eval_equation('default_value(1.5, 10.0)'))
+    assert_equal(1.5, parsec.eval_equation('default_value(1.5, 10.5)'))
+
     # Error Scenarios
-    assert_raises(SyntaxError) { parsec.eval_equation('default_value(1, 4.5)') }
     assert_raises(SyntaxError) { parsec.eval_equation('default_value(4.5, "string")') }
     assert_raises(SyntaxError) { parsec.eval_equation('default_value("string", true)') }
     assert_raises(SyntaxError) { parsec.eval_equation('default_value(true, 1)') }


### PR DESCRIPTION
# Description 🗒️ 

This PRs converts integers to floats inside the `default_value()` evaluation, fixing the `default_value()` numbers incompatibility issue.

Now, this function is much more flexible to play with **integer** and **float** parameters.

For example...

```rb
parsec> default_value(1, 10)
Result (type: 'i'):
ans = 1

parsec> default_value(1, 10.0)
Result (type: 'i'):
ans = 1

parsec> default_value(1.0, 10)
Result (type: 'i'):
ans = 1

parsec> default_value(1.0, 10.0)
Result (type: 'i'):
ans = 1

parsec> default_value(1.5, 10)
Result (type: 'f'):
ans = 1.5

parsec> default_value(1.5, 10.0)
Result (type: 'f'):
ans = 1.5

parsec> default_value(1.5, 10.5)
Result (type: 'f'):
ans = 1.5
```

# Bug 🐛 

![SLA error reason](https://user-images.githubusercontent.com/7637806/95136053-c97fe880-073b-11eb-8b88-a21901fba20c.png)

# Checks ✔️ 

- [x] Fix default_value() numbers incompatibility
- [x] Add automated tests for default_value() numbers incompatibility
- [x] Update gem version
- [x] Smoke Tests

# Automated Tests 🤖 

```rb
$ ruby -Ilib -Iext/libnativemath test/test_parsec.rb
Run options: --seed 7030

# Running:

..................

Finished in 0.020919s, 860.4618 runs/s, 7074.9080 assertions/s.

18 runs, 148 assertions, 0 failures, 0 errors, 0 skips
```