### PR TITLE
Adds link() function to Parsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ gem 'parsecs'
 
 ```ruby
 gem build parsec.gemspec
-gem install ./parsecs-VERSION.gem (e.g.: gem install ./parsecs-0.8.1.gem)
+gem install ./parsecs-VERSION.gem (e.g.: gem install ./parsecs-0.9.0.gem)
 ruby -Ilib -Iext/libnativemath test/test_parsec.rb
 ```
 
@@ -86,6 +86,7 @@ parser.eval_equation('length("test string")')     # result => 11
 parser.eval_equation('toupper("test string")')    # result => "TEST STRING"
 parser.eval_equation('tolower("TEST STRING")')    # result => "test string"
 parser.eval_equation('concat("Hello ", "World")') # result => "Hello World"
+parser.eval_equation('link("Title", "http://foo.bar")') # result => "<a href=\"http://foo.bar\">Title</a>"
 parser.eval_equation('str2number("5")')           # result => 5
 parser.eval_equation('left("Hello World", 5)')    # result => "Hello"
 parser.eval_equation('right("Hello World", 5)')   # result => "World"
@@ -111,7 +112,7 @@ parsec.eval_equation('hoursdiff("2018-01-01", "2018-01-01")')             # resu
 * Number functions: **string**
 * Math constants: **e**, **pi**
 * Unlimited number of arguments: **min**, **max**, **sum**, **avg**
-* String functions: **concat**, **length**, **toupper**, **tolower**, **left**, **right**, **str2number**, **number**
+* String functions: **concat**, **length**, **toupper**, **tolower**, **left**, **right**, **str2number**, **number**, **link**
 * Complex functions: **real**, **imag**, **conj**, **arg**, **norm**
 * Array functions: **sizeof**, **eye**, **ones**, **zeros**
 * Date functions: **current_date**, **daysdiff**, **hoursdiff**

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/niltonvasques/equations-parser.git'.freeze
-COMMIT = 'f83b631eff678b9c6bf1c2d31e524c1b587cb048'.freeze
+COMMIT = '8acd8d964531f1b78ef905ccdace7b7b038e9d8d'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.8.1'.freeze
+    VERSION = '0.9.0'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.8.1'
+  s.version               = '0.9.0'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -60,6 +60,12 @@ class TestParsec < Minitest::Test
     assert_equal(5, parser.eval_equation('number("5")'))
     assert_equal('Hello', parser.eval_equation('left("Hello World", 5)'))
     assert_equal('World', parser.eval_equation('right("Hello World", 5)'))
+    assert_equal('<a href=\"http://foo.bar\">Title</a>', parser.eval_equation('link("Title", "http://foo.bar")'))
+    assert_equal('<a href=\"#\">Title</a>', parser.eval_equation('link("Title", "#")'))
+    assert_equal('<a href=\"/test\">Test title</a>', parser.eval_equation('link("Test title", "/test")'))
+    assert_raises(SyntaxError) { parser.eval_equation_with_type('link()') }
+    assert_raises(SyntaxError) { parser.eval_equation_with_type('link(1, 2, 3)') }
+    assert_raises(SyntaxError) { parser.eval_equation_with_type('link(1, "2")') }
   end
 
   def test_complex_string_manipulation


### PR DESCRIPTION
# Description 🗒️ 

This PR updates the `equations-parser` lib to permit `link()` usage and adds tests for it.

Examples of usage:

```ruby
parsec> link("Title", "http://foo.bar/baz")
Result (type: 's'):
ans = "<a href=\"http://foo.bar/baz\">Title</a>"

parsec> link("another Title", "#")
Result (type: 's'):
ans = "<a href=\"#\">another Title</a>"

parsec> link("aloo", "http://google.com")
Result (type: 's'):
ans = "<a href=\"http://google.com\">aloo</a>"
```

Checks ✔️ 
* [x]  Add automated tests for link() function
* [x]  Update gem version
* [ ]  Smoke Tests

# Automated Tests 🤖 
```ruby
$ ruby -Ilib -Iext/libnativemath test/test_parsec.rb
Run options: --seed 60688

# Running:

..................

Finished in 0.022153s, 812.5170 runs/s, 6951.5342 assertions/s.
18 runs, 154 assertions, 0 failures, 0 errors, 0 skips
```
