### PR TITLE
DPMS-14239 Update Parsec to include the new Contains function

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/niltonvasques/equations-parser.git'.freeze
-COMMIT = 'd35b30205dd08f80ceb01df003a376c95a715bb6'.freeze
+COMMIT = '948c6e5f32030e1d96b7fc8cd6215edb8168e75e'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.9.3'.freeze
+    VERSION = '0.10.3'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.9.3'
+  s.version               = '0.10.3'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -63,6 +63,15 @@ class TestParsec < Minitest::Test
     assert_equal('<a href="http://foo.bar">Title</a>', parser.eval_equation('link("Title", "http://foo.bar")'))
     assert_equal('<a href="#">Title</a>', parser.eval_equation('link("Title", "#")'))
     assert_equal('<a href="/test">Test title</a>', parser.eval_equation('link("Test title", "/test")'))
+    assert_equal(true, parser.eval_equation('contains("Hello World", "orld")'))
+    assert_equal(true, parser.eval_equation('contains("One Flew Over The Cuckoo\'s", "koo")'))
+    assert_equal(false, parser.eval_equation('contains("Hello World", "Worlds")'))
+    assert_equal(true, parser.eval_equation('contains("1234567", "456")'))
+    assert_equal(false, parser.eval_equation('contains("1234567", "789")'))
+    assert_equal(true, parser.eval_equation('contains("2019-01-01T:08:30", "2019-01-01")'))
+    assert_equal(false, parser.eval_equation('contains("2019-01-01T:08:30", "2021-01-01")'))
+    assert_raises(SyntaxError) { parser.eval_equation('contains(1234567, "789")') }
+    assert_raises(SyntaxError) { parser.eval_equation('contains("hello", 2.2)') }
     assert_raises(SyntaxError) { parser.eval_equation_with_type('link()') }
     assert_raises(SyntaxError) { parser.eval_equation_with_type('link(1, 2, 3)') }
     assert_raises(SyntaxError) { parser.eval_equation_with_type('link(1, "2")') }


### PR DESCRIPTION
### Description
  Updates the Parsec to include the new _Contains_ function, making the appropriate changes to the commit string and the version number, and also adds a few tests to verify that the _Contains_ function is working properly.

### Example
 ```  C++
  contains("Hello World", "orld");
  => true
  contains("One Flew Over The Cuckoo's", "Nest");
  => false
  contains("1234567", "456");
  => true
```

[Contains function's PR](https://github.com/niltonvasques/equations-parser/pull/36)

[Jira's Ticket](https://kaeferdpms.atlassian.net/browse/DPMS-14239)