### PR TITLE
Adds timediff() function to Parsec

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/niltonvasques/equations-parser.git'.freeze
-COMMIT = '948c6e5f32030e1d96b7fc8cd6215edb8168e75e'.freeze
+COMMIT = '6846102ba56050057d04c9d63d9be1d260c5fe16'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.10.3'.freeze
+    VERSION = '0.11.0'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.10.3'
+  s.version               = '0.11.0'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -272,4 +272,21 @@ class TestParsec < Minitest::Test
     assert_raises(SyntaxError) { parsec.eval_equation_with_type('concat(1, 2)') }
     assert_raises(SyntaxError) { parsec.eval_equation_with_type('4 > 2 ? "smaller"') }
   end
+
+  def test_timediff
+    parsec = Parsec::Parsec
+    assert_equal(1.5, parsec.eval_equation('timediff("02:00:00", "03:30:00")'))
+    assert_equal(22.5, parsec.eval_equation('timediff("03:30:00", "02:00:00")'))
+    assert_equal(0.01, parsec.eval_equation('timediff("02:00:00", "02:00:30")'))
+    assert_equal(23.99, parsec.eval_equation('timediff("02:00:30", "02:00:00")'))
+    assert_equal(0.0, parsec.eval_equation('timediff("02:00:00", "02:00:00")'))
+
+    # error scenarios
+    assert_raises(SyntaxError) { parsec.eval_equation('timediff("02:00:30", "02/01/20")') }
+    assert_raises(SyntaxError) { parsec.eval_equation('timediff("02:00:30", "02/01/20T02:00:30")') }
+    assert_raises(SyntaxError) { parsec.eval_equation('timediff("02/01/20", "02:00:30")') }
+    assert_raises(SyntaxError) { parsec.eval_equation('timediff("02:00:30", "02:61:30")') }
+    assert_raises(SyntaxError) { parsec.eval_equation('timediff("02:00:00", "02:30:62")') }
+    assert_raises(SyntaxError) { parsec.eval_equation('timediff("24:00:00", "02:30:59")') }
+  end
 end


### PR DESCRIPTION
# Description

Updates the Parsec to include the new `timediff` function, making the appropriate changes to the commit string and the version number, and also adds a few tests to verify that the `timediff` function is working properly.

# Example
![2021-08-26_22-49](https://user-images.githubusercontent.com/5000206/131356987-f97cfed3-7826-4eb0-9cf0-37a88bce51c6.png)

# [Commit with update](https://github.com/niltonvasques/equations-parser/commit/6846102ba56050057d04c9d63d9be1d260c5fe16)
![2021-08-30_11-41](https://user-images.githubusercontent.com/5000206/131357579-c90aff54-56fa-4e9a-8eae-66758a8ad1f7.png)


# Tests output
![2021-08-30_11-38](https://user-images.githubusercontent.com/5000206/131357038-528acb05-1353-471b-9406-3554e901489d.png)

