### PR TITLE
Fix right(x, y) string lenght bug

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/niltonvasques/equations-parser.git'.freeze
-COMMIT = '6846102ba56050057d04c9d63d9be1d260c5fe16'.freeze
+COMMIT = 'b011ace5697fa65eade579f1c85aa38fd1fb816d'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.11.0'.freeze
+    VERSION = '0.11.1'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.11.0'
+  s.version               = '0.11.1'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -84,6 +84,7 @@ class TestParsec < Minitest::Test
     assert_equal('test lowercase', parser.eval_equation('tolower("TEST LOWERCASE")'))
     assert_equal('Hello', parser.eval_equation('left("Hello World", 5)'))
     assert_equal('World', parser.eval_equation('right("Hello World", 5)'))
+    assert_equal('Hello World', parser.eval_equation('right("Hello World", 20)'))
   end
 
   def test_general_equations


### PR DESCRIPTION
This PR fixes the bug where right('str', 4) would throw a std::out_of_range error 

# [Commit with update](niltonvasques/equations-parser@b011ace)
![WorkingAsIntended](https://user-images.githubusercontent.com/26317903/134189419-0cf4fba1-e2b3-49e0-98f6-c17f5e56e92b.png)



# Tests output
![TestsOutput](https://user-images.githubusercontent.com/26317903/134189154-0714f276-5514-4105-99d5-4ea5d4bf91cb.png)

