### PR TITLE
Avoid clean whitespace when have escaped double quote on string

### DIFF
--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -49,7 +49,7 @@ module Parsec
 
       # The following regex remove all spaces that are not between quot marks
       # https://tinyurl.com/ybc7bng3
-      equation = equation.gsub(/( |(".*?"))/, '\\2') if new_line == true
+      equation = equation.gsub(/( |(".*?[^\\]"))/, '\\2') if new_line == true
 
       equation
     end

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -56,6 +56,7 @@ class TestParsec < Minitest::Test
     assert_equal('TEST STRING', parser.eval_equation('toupper("test string")'))
     assert_equal('test string', parser.eval_equation('tolower("TEST STRING")'))
     assert_equal('Hello World', parser.eval_equation('concat("Hello ", "World")'))
+    assert_equal('tes t "str \" " ing equa  "   tion', parser.eval_equation('concat(concat("tes t", " \\"str \\\\\" \\" ing "),string("equa  \\"   tion"))'))
     assert_equal(5, parser.eval_equation('str2number("5")'))
     assert_equal(5, parser.eval_equation('number("5")'))
     assert_equal('Hello', parser.eval_equation('left("Hello World", 5)'))


### PR DESCRIPTION
### Overview

This PR avoid gsub regex from remove whitespaces from strings if they use escaped double quote.

### Before
![image](https://user-images.githubusercontent.com/38773806/189750383-5e5a603e-f0b5-4a77-8ae9-b283a50778b1.png)

### After
![image](https://user-images.githubusercontent.com/38773806/189750558-d123d40c-4262-40d4-857f-01f3b8c0cd82.png)
