### PR TITLE
Update parsec link equation

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/niltonvasques/equations-parser.git'.freeze
-COMMIT = 'b011ace5697fa65eade579f1c85aa38fd1fb816d'.freeze
+COMMIT = 'd49225cddcf2fb08d8604fc2a7e6198983dcd1b9'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/ext/libnativemath/mkmf.log
+++ b/ext/libnativemath/mkmf.log
@@ -1,0 +1,8 @@
+find_executable: checking for cmake... -------------------- yes
+
+--------------------
+
+find_executable: checking for swig... -------------------- yes
+
+--------------------
+

--- a/ext/libnativemath/mkmf.log
+++ b/ext/libnativemath/mkmf.log
@@ -1,8 +1,0 @@
-find_executable: checking for cmake... -------------------- yes
-
---------------------
-
-find_executable: checking for swig... -------------------- yes
-
---------------------
-

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.11.3'.freeze
+    VERSION = '0.11.4'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.11.3'
+  s.version               = '0.11.4'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -64,6 +64,7 @@ class TestParsec < Minitest::Test
     assert_equal('<a href="http://foo.bar">Title</a>', parser.eval_equation('link("Title", "http://foo.bar")'))
     assert_equal('<a href="#">Title</a>', parser.eval_equation('link("Title", "#")'))
     assert_equal('<a href="/test">Test title</a>', parser.eval_equation('link("Test title", "/test")'))
+    assert_equal('<a href="/test" download="testFileName">Test title</a>', parser.eval_equation('link("Test title", "/test", "testFileName")'))
     assert_equal(true, parser.eval_equation('contains("Hello World", "orld")'))
     assert_equal(true, parser.eval_equation('contains("One Flew Over The Cuckoo\'s", "koo")'))
     assert_equal(false, parser.eval_equation('contains("Hello World", "Worlds")'))
@@ -75,8 +76,10 @@ class TestParsec < Minitest::Test
     assert_raises(SyntaxError) { parser.eval_equation('contains(1234567, "789")') }
     assert_raises(SyntaxError) { parser.eval_equation('contains("hello", 2.2)') }
     assert_raises(SyntaxError) { parser.eval_equation_with_type('link()') }
+    assert_raises(SyntaxError) { parser.eval_equation_with_type('link("1")') }
     assert_raises(SyntaxError) { parser.eval_equation_with_type('link(1, 2, 3)') }
     assert_raises(SyntaxError) { parser.eval_equation_with_type('link(1, "2")') }
+    assert_raises(SyntaxError) { parser.eval_equation_with_type('link("1","2","3","4")') }
   end
 
   def test_complex_string_manipulation


### PR DESCRIPTION
# Description ✍️ 

This PR update parsec version to get the updated link equation from `equations-parser`.

### `equations-parser` changes 🆕 

This PR adds an optional attribute download to the link equation.

Now is possible to pass an additional string parameter which will be the file name in case of a downloadable file link.

![image](https://user-images.githubusercontent.com/38773806/191341488-ceaf2e4b-77ac-4b6a-855c-f22ca25c604a.png)

> It will be possible to pass more than 3 parameters, but in this update, only the 3 firsts will be used in the anchor tag returned. 
> It will also be possible to pass less than 2 parameters, in these cases, the link returns nothing.