### PR TITLE
Fixes empty string on concat equation

### DIFF
--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.11.4'.freeze
+    VERSION = '0.11.5'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)
@@ -49,7 +49,7 @@ module Parsec
 
       # The following regex remove all spaces that are not between quot marks
       # https://tinyurl.com/ybc7bng3
-      equation = equation.gsub(/( |(".*?[^\\]"))/, '\\2') if new_line == true
+      equation = equation.gsub(/( |(".*?[^\\]"))/, '\\0') if new_line == true
 
       equation
     end

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -49,7 +49,9 @@ module Parsec
 
       # The following regex remove all spaces that are not between quot marks
       # https://tinyurl.com/ybc7bng3
-      equation = equation.gsub(/( |(".*?[^\\]"))/, '\\0') if new_line == true
+      if new_line == true
+        equation.gsub!(/( |("([^"\\]|\\.)*")|('([^'\\]|\\.)*'))/, '\\2')
+      end
 
       equation
     end

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.11.4'
+  s.version               = '0.11.5'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -56,6 +56,8 @@ class TestParsec < Minitest::Test
     assert_equal('TEST STRING', parser.eval_equation('toupper("test string")'))
     assert_equal('test string', parser.eval_equation('tolower("TEST STRING")'))
     assert_equal('Hello World', parser.eval_equation('concat("Hello ", "World")'))
+    assert_equal('Hello World', parser.eval_equation('concat("", "Hello World")'))
+    assert_equal('Hello World', parser.eval_equation('concat("Hello World", "")'))
     assert_equal('tes t "str \" " ing equa  "   tion', parser.eval_equation('concat(concat("tes t", " \\"str \\\\\" \\" ing "),string("equa  \\"   tion"))'))
     assert_equal(5, parser.eval_equation('str2number("5")'))
     assert_equal(5, parser.eval_equation('number("5")'))


### PR DESCRIPTION
This PR fixes the usage of an empty string on concat equation, avoiding it remove whitespaces.

The regex used on gsub was removing whitespaces.

![image](https://user-images.githubusercontent.com/38773806/194923777-268d884e-b9ab-4f4c-a74c-8d63376ba9a8.png)
