### PR TITLE
Fix decimal precision

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/niltonvasques/equations-parser.git'.freeze
-COMMIT = 'd49225cddcf2fb08d8604fc2a7e6198983dcd1b9'.freeze
+COMMIT = 'fe93ca5534484b05cd1eb68f7acfc32ff05dc20c'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/ext/libnativemath/libnativemath.cpp
+++ b/ext/libnativemath/libnativemath.cpp
@@ -48,6 +48,6 @@ int native_eval(string input, char *value, char *value_type) {
 
   value_type[0] = ans.GetType();
 
-  strcpy(value, ans.ToString().c_str());
+  strcpy(value, ans.AsString().c_str());
   return 0;
 }

--- a/ext/libnativemath/libnativemath.cpp
+++ b/ext/libnativemath/libnativemath.cpp
@@ -48,6 +48,6 @@ int native_eval(string input, char *value, char *value_type) {
 
   value_type[0] = ans.GetType();
 
-  strcpy(value, ans.AsString().c_str());
+  strcpy(value, ans.ToString().c_str());
   return 0;
 }

--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.11.5'.freeze
+    VERSION = '0.11.6'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.11.5'
+  s.version               = '0.11.6'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -13,6 +13,11 @@ class TestParsec < Minitest::Test
     parser = Parsec::Parsec
     assert_equal(10, parser.eval_equation('(5 + 1) + (6 - 2)'))
     assert_equal(16, parser.eval_equation('4 + 4 * 3'))
+    assert_equal(604.1952, parser.eval_equation('35.52 * 17.01'))
+    assert_equal(404.5728, parser.eval_equation('35.52 * 11.39'))
+    assert_equal(634.2688, parser.eval_equation('11.84 * 53.57'))
+    assert_equal(423.3984, parser.eval_equation('11.84 * 35.76'))
+    assert_equal(309.96528, parser.eval_equation('(604.1952 + 404.5728 + 634.2688 + 423.3984) * 0.15'))
     assert_equal(2, parser.eval_equation('10.5 / 5.25'))
     assert_equal(5, parser.eval_equation('abs(-5)'))
     assert_equal(1, parser.eval_equation('log10(10)'))

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -35,11 +35,11 @@ class TestParsec < Minitest::Test
 
   def test_if_then_else_equations
     parser = Parsec::Parsec
-    assert_equal('"bigger"', parser.eval_equation('4 > 2 ? "bigger" : "smaller"'))
+    assert_equal('bigger', parser.eval_equation('4 > 2 ? "bigger" : "smaller"'))
     assert_equal(true, parser.eval_equation('2 == 2 ? true : false'))
     assert_equal(false, parser.eval_equation('2 != 2 ? true : false'))
-    assert_equal('"yes"', parser.eval_equation('"this" == "this" ? "yes" : "no"'))
-    assert_equal('"yes"', parser.eval_equation('"this" != "that" ? "yes" : "no"'))
+    assert_equal('yes', parser.eval_equation('"this" == "this" ? "yes" : "no"'))
+    assert_equal('yes', parser.eval_equation('"this" != "that" ? "yes" : "no"'))
   end
 
   def test_logic_manipulation
@@ -53,20 +53,20 @@ class TestParsec < Minitest::Test
   def test_simple_string_manipulation
     parser = Parsec::Parsec
     assert_equal(11, parser.eval_equation('length("test string")'))
-    assert_equal('"TEST STRING"', parser.eval_equation('toupper("test string")'))
-    assert_equal('"test string"', parser.eval_equation('tolower("TEST STRING")'))
-    assert_equal('"Hello World"', parser.eval_equation('concat("Hello ", "World")'))
-    assert_equal('"Hello World"', parser.eval_equation('concat("", "Hello World")'))
-    assert_equal('"Hello World"', parser.eval_equation('concat("Hello World", "")'))
-    assert_equal('"tes t "str \" " ing equa  "   tion"', parser.eval_equation('concat(concat("tes t", " \\"str \\\\\" \\" ing "),string("equa  \\"   tion"))'))
+    assert_equal('TEST STRING', parser.eval_equation('toupper("test string")'))
+    assert_equal('test string', parser.eval_equation('tolower("TEST STRING")'))
+    assert_equal('Hello World', parser.eval_equation('concat("Hello ", "World")'))
+    assert_equal('Hello World', parser.eval_equation('concat("", "Hello World")'))
+    assert_equal('Hello World', parser.eval_equation('concat("Hello World", "")'))
+    assert_equal('tes t "str \" " ing equa  "   tion', parser.eval_equation('concat(concat("tes t", " \\"str \\\\\" \\" ing "),string("equa  \\"   tion"))'))
     assert_equal(5, parser.eval_equation('str2number("5")'))
     assert_equal(5, parser.eval_equation('number("5")'))
-    assert_equal('"Hello"', parser.eval_equation('left("Hello World", 5)'))
-    assert_equal('"World"', parser.eval_equation('right("Hello World", 5)'))
-    assert_equal('"<a href="http://foo.bar">Title</a>"', parser.eval_equation('link("Title", "http://foo.bar")'))
-    assert_equal('"<a href="#">Title</a>"', parser.eval_equation('link("Title", "#")'))
-    assert_equal('"<a href="/test">Test title</a>"', parser.eval_equation('link("Test title", "/test")'))
-    assert_equal('"<a href="/test" download="testFileName">Test title</a>"', parser.eval_equation('link("Test title", "/test", "testFileName")'))
+    assert_equal('Hello', parser.eval_equation('left("Hello World", 5)'))
+    assert_equal('World', parser.eval_equation('right("Hello World", 5)'))
+    assert_equal('<a href="http://foo.bar">Title</a>', parser.eval_equation('link("Title", "http://foo.bar")'))
+    assert_equal('<a href="#">Title</a>', parser.eval_equation('link("Title", "#")'))
+    assert_equal('<a href="/test">Test title</a>', parser.eval_equation('link("Test title", "/test")'))
+    assert_equal('<a href="/test" download="testFileName">Test title</a>', parser.eval_equation('link("Test title", "/test", "testFileName")'))
     assert_equal(true, parser.eval_equation('contains("Hello World", "orld")'))
     assert_equal(true, parser.eval_equation('contains("One Flew Over The Cuckoo\'s", "koo")'))
     assert_equal(false, parser.eval_equation('contains("Hello World", "Worlds")'))
@@ -74,7 +74,7 @@ class TestParsec < Minitest::Test
     assert_equal(false, parser.eval_equation('contains("1234567", "789")'))
     assert_equal(true, parser.eval_equation('contains("2019-01-01T:08:30", "2019-01-01")'))
     assert_equal(false, parser.eval_equation('contains("2019-01-01T:08:30", "2021-01-01")'))
-    assert_equal('"Maçã"', parser.eval_equation('"Maçã"'))
+    assert_equal('Maçã', parser.eval_equation('"Maçã"'))
     assert_raises(SyntaxError) { parser.eval_equation('contains(1234567, "789")') }
     assert_raises(SyntaxError) { parser.eval_equation('contains("hello", 2.2)') }
     assert_raises(SyntaxError) { parser.eval_equation_with_type('link()') }
@@ -86,12 +86,12 @@ class TestParsec < Minitest::Test
 
   def test_complex_string_manipulation
     parser = Parsec::Parsec
-    assert_equal('"string with quote""', parser.eval_equation('"string with quote\""'))
-    assert_equal('"HELLO WORLD"', parser.eval_equation('toupper(concat("hello ", "world"))'))
-    assert_equal('"test lowercase"', parser.eval_equation('tolower("TEST LOWERCASE")'))
-    assert_equal('"Hello"', parser.eval_equation('left("Hello World", 5)'))
-    assert_equal('"World"', parser.eval_equation('right("Hello World", 5)'))
-    assert_equal('"Hello World"', parser.eval_equation('right("Hello World", 20)'))
+    assert_equal('string with quote"', parser.eval_equation('"string with quote\""'))
+    assert_equal('HELLO WORLD', parser.eval_equation('toupper(concat("hello ", "world"))'))
+    assert_equal('test lowercase', parser.eval_equation('tolower("TEST LOWERCASE")'))
+    assert_equal('Hello', parser.eval_equation('left("Hello World", 5)'))
+    assert_equal('World', parser.eval_equation('right("Hello World", 5)'))
+    assert_equal('Hello World', parser.eval_equation('right("Hello World", 20)'))
   end
 
   def test_general_equations
@@ -100,7 +100,7 @@ class TestParsec < Minitest::Test
     assert_equal(40.6853365119738, parsec.eval_equation('10^log(3+2)'))
     assert_equal(1, parsec.eval_equation('log(e)'))
     assert_equal(2, parsec.eval_equation('2^5^0'))
-    assert_equal('"yes"', parsec.eval_equation('5 > 3 ? "yes" : "no"'))
+    assert_equal('yes', parsec.eval_equation('5 > 3 ? "yes" : "no"'))
     assert_equal(1, parsec.eval_equation('"this" == "this" ? 1 : 0'))
     assert_equal(9.9812, parsec.eval_equation('sqrt(9)+cbrt(8)+abs(-4.9812)'))
     assert_equal(3_628_680, parsec.send(:eval_equation, '10! - 5! * -(-1)'))
@@ -108,8 +108,8 @@ class TestParsec < Minitest::Test
     assert_equal(0.55, parsec.eval_equation('avg(1,2,3,4,5,6,7,8,9,10) / 10'))
     assert_equal(5, parsec.eval_equation('round(4.62)'))
     assert_equal(4.63, parsec.eval_equation('round_decimal(4.625, 2)'))
-    assert_equal('"5"', parsec.eval_equation('string(5)'))
-    assert_equal('"5.123"', parsec.eval_equation('string(5.123)'))
+    assert_equal('5', parsec.eval_equation('string(5)'))
+    assert_equal('5.123', parsec.eval_equation('string(5.123)'))
   end
 
   def test_newlines_remotion
@@ -127,7 +127,7 @@ class TestParsec < Minitest::Test
   def test_validate_syntax
     parsec = Parsec::Parsec
     refute_equal(true, parsec.validate_syntax('((0.09/1.0)+2.58)-1.6+'))
-    assert_equal('"Missing parenthesis."', parsec.validate_syntax('(0.09/1.0'))
+    assert_equal('Missing parenthesis.', parsec.validate_syntax('(0.09/1.0'))
   end
 
   def test_validate_syntax!
@@ -139,7 +139,7 @@ class TestParsec < Minitest::Test
   def test_date_functions
     parsec = Parsec::Parsec
     assert_equal(Date.today, Date.parse(parsec.eval_equation('current_date()')))
-    assert_match(/^"\d{4}-\d{2}-\d{2}"$/, parsec.eval_equation('current_date()'))
+    assert_match(/^\d{4}-\d{2}-\d{2}$/, parsec.eval_equation('current_date()'))
     assert_equal(364, parsec.eval_equation('daysdiff("2018-01-01", "2018-12-31")'))
     assert_equal(365, parsec.eval_equation('daysdiff("2016-01-01", "2016-12-31")'))
     assert_equal(365, parsec.eval_equation('daysdiff("2000-01-01", "2000-12-31")'))
@@ -178,17 +178,17 @@ class TestParsec < Minitest::Test
     parsec = Parsec::Parsec
 
     # With Dates
-    assert_equal('"2019-01-01"', parsec.eval_equation('add_days("2019-01-01", 0)'))
-    assert_equal('"2019-01-02"', parsec.eval_equation('add_days("2019-01-01", 1)'))
-    assert_equal('"2018-12-31"', parsec.eval_equation('add_days("2019-01-01", -1)'))
-    assert_equal('"2019-01-04"', parsec.eval_equation('add_days("2019-01-01", 3)'))
+    assert_equal('2019-01-01', parsec.eval_equation('add_days("2019-01-01", 0)'))
+    assert_equal('2019-01-02', parsec.eval_equation('add_days("2019-01-01", 1)'))
+    assert_equal('2018-12-31', parsec.eval_equation('add_days("2019-01-01", -1)'))
+    assert_equal('2019-01-04', parsec.eval_equation('add_days("2019-01-01", 3)'))
 
     # # With DateTimes
-    assert_equal('"2019-01-01T08:30"', parsec.eval_equation('add_days("2019-01-01T08:30", 0)'))
-    assert_equal('"2019-02-01T12:30"', parsec.eval_equation('add_days("2019-01-01T12:30", 31)'))
-    assert_equal('"2019-01-02T15:30"', parsec.eval_equation('add_days("2019-01-01T15:30", 1)'))
-    assert_equal('"2019-01-02T20:30"', parsec.eval_equation('add_days("2019-01-01T08:30", 1.5)'))
-    assert_equal('"2018-12-31T08:30"', parsec.eval_equation('add_days("2019-01-01T08:30", -1)'))
+    assert_equal('2019-01-01T08:30', parsec.eval_equation('add_days("2019-01-01T08:30", 0)'))
+    assert_equal('2019-02-01T12:30', parsec.eval_equation('add_days("2019-01-01T12:30", 31)'))
+    assert_equal('2019-01-02T15:30', parsec.eval_equation('add_days("2019-01-01T15:30", 1)'))
+    assert_equal('2019-01-02T20:30', parsec.eval_equation('add_days("2019-01-01T08:30", 1.5)'))
+    assert_equal('2018-12-31T08:30', parsec.eval_equation('add_days("2019-01-01T08:30", -1)'))
 
     # With Errors
     assert_raises(SyntaxError) { parsec.eval_equation_with_type('add_days("2019-01-33", 0)') }
@@ -200,25 +200,25 @@ class TestParsec < Minitest::Test
 
   def test_mask
     parsec = Parsec::Parsec
-    assert_equal('"123-456"', parsec.eval_equation('mask("000-000", 123456)'))
-    assert_equal('"00014"', parsec.eval_equation('mask("00000", 14)'))
-    assert_equal('"000 14"', parsec.eval_equation('mask("000 00", 14)'))
-    assert_equal('"#123"', parsec.eval_equation('concat("#", mask("000", 123))'))
-    assert_equal('"12345"', parsec.eval_equation('mask("0000", 12345)'))
-    assert_equal('"123 45"', parsec.eval_equation('mask("00 00", 12345)'))
-    assert_equal('"3-5591-1801"', parsec.eval_equation('mask("0-0000-0000", 355911801)'))
-    assert_equal('"35-5591-1801"', parsec.eval_equation('mask("00-0000-0000", 3555911801)'))
-    assert_equal('"12-1234-1234-1234"', parsec.eval_equation('mask("00-0000-0000-0000", 12123412341234)'))
-    assert_equal('"1-1234-1234-1234-1234"', parsec.eval_equation('mask("0-0000-0000-0000-0000", 11234123412341234)'))
+    assert_equal('123-456', parsec.eval_equation('mask("000-000", 123456)'))
+    assert_equal('00014', parsec.eval_equation('mask("00000", 14)'))
+    assert_equal('000 14', parsec.eval_equation('mask("000 00", 14)'))
+    assert_equal('#123', parsec.eval_equation('concat("#", mask("000", 123))'))
+    assert_equal('12345', parsec.eval_equation('mask("0000", 12345)'))
+    assert_equal('123 45', parsec.eval_equation('mask("00 00", 12345)'))
+    assert_equal('3-5591-1801', parsec.eval_equation('mask("0-0000-0000", 355911801)'))
+    assert_equal('35-5591-1801', parsec.eval_equation('mask("00-0000-0000", 3555911801)'))
+    assert_equal('12-1234-1234-1234', parsec.eval_equation('mask("00-0000-0000-0000", 12123412341234)'))
+    assert_equal('1-1234-1234-1234-1234', parsec.eval_equation('mask("0-0000-0000-0000-0000", 11234123412341234)'))
   end
 
   def test_string_cast
     parsec = Parsec::Parsec
-    assert_equal('"4"', parsec.eval_equation('string(4)'))
-    assert_equal('"4.5"', parsec.eval_equation('string(4.5)'))
-    assert_equal('"true"', parsec.eval_equation('string(true)'))
-    assert_equal('"false"', parsec.eval_equation('string(false)'))
-    assert_equal('"4"', parsec.eval_equation('string("4")'))
+    assert_equal('4', parsec.eval_equation('string(4)'))
+    assert_equal('4.5', parsec.eval_equation('string(4.5)'))
+    assert_equal('true', parsec.eval_equation('string(true)'))
+    assert_equal('false', parsec.eval_equation('string(false)'))
+    assert_equal('4', parsec.eval_equation('string("4")'))
   end
 
   def test_number_cast
@@ -238,8 +238,8 @@ class TestParsec < Minitest::Test
     assert_equal(1, parsec.eval_equation('default_value(NULL, 1)'))
     assert_equal(10.4, parsec.eval_equation('default_value(10.4, 1.01)'))
     assert_equal(1.01, parsec.eval_equation('default_value(NULL, 1.01)'))
-    assert_equal('"filled"', parsec.eval_equation('default_value("filled", "default")'))
-    assert_equal('"default"', parsec.eval_equation('default_value(NULL, "default")'))
+    assert_equal('filled', parsec.eval_equation('default_value("filled", "default")'))
+    assert_equal('default', parsec.eval_equation('default_value(NULL, "default")'))
     assert_equal(false, parsec.eval_equation('default_value(false, true)'))
     assert_equal(true, parsec.eval_equation('default_value(NULL, true)'))
 
@@ -268,8 +268,8 @@ class TestParsec < Minitest::Test
     assert_equal({ value: 40.6853365119738, type: :float }, parsec.eval_equation_with_type('10^log(3+2)'))
     assert_equal({ value: 5.1, type: :float }, parsec.eval_equation_with_type('number("5.1")'))
     equation_if = '4 > 2 ? "bigger" : "smaller"'
-    assert_equal({ value: '"bigger"', type: :string }, parsec.eval_equation_with_type(equation_if))
-    assert_equal({ value: '"5.123"', type: :string }, parsec.eval_equation_with_type('string(5.123)'))
+    assert_equal({ value: 'bigger', type: :string }, parsec.eval_equation_with_type(equation_if))
+    assert_equal({ value: '5.123', type: :string }, parsec.eval_equation_with_type('string(5.123)'))
     equation_boolean = '2 == 2 ? true : false'
     assert_equal({ value: true, type: :boolean }, parsec.eval_equation_with_type(equation_boolean))
     equation_boolean = '(3==3) and (3!=3)'

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -25,8 +25,8 @@ class TestParsec < Minitest::Test
   def test_complex_math_equations
     parser = Parsec::Parsec
     assert_equal(6, parser.eval_equation('sqrt(16) + cbrt(8)'))
-    assert_equal(4.30259, parser.eval_equation('log10(10) + ln(e) + log(10)'))
-    assert_equal(2.0, parser.eval_equation('sin(1) + cos(0) + tan(0.15722)'))
+    assert_equal(4.30258509299405, parser.eval_equation('log10(10) + ln(e) + log(10)'))
+    assert_equal(1.99999931685569, parser.eval_equation('sin(1) + cos(0) + tan(0.15722)'))
     assert_equal(16, parser.eval_equation('max(1, 2) + min(3, 4) + sum(5, 6)'))
     assert_equal(9.6, parser.eval_equation('avg(9, 9.8, 10)'))
     assert_equal(8, parser.eval_equation('pow(2, 3)'))
@@ -35,11 +35,11 @@ class TestParsec < Minitest::Test
 
   def test_if_then_else_equations
     parser = Parsec::Parsec
-    assert_equal('bigger', parser.eval_equation('4 > 2 ? "bigger" : "smaller"'))
+    assert_equal('"bigger"', parser.eval_equation('4 > 2 ? "bigger" : "smaller"'))
     assert_equal(true, parser.eval_equation('2 == 2 ? true : false'))
     assert_equal(false, parser.eval_equation('2 != 2 ? true : false'))
-    assert_equal('yes', parser.eval_equation('"this" == "this" ? "yes" : "no"'))
-    assert_equal('yes', parser.eval_equation('"this" != "that" ? "yes" : "no"'))
+    assert_equal('"yes"', parser.eval_equation('"this" == "this" ? "yes" : "no"'))
+    assert_equal('"yes"', parser.eval_equation('"this" != "that" ? "yes" : "no"'))
   end
 
   def test_logic_manipulation
@@ -53,20 +53,20 @@ class TestParsec < Minitest::Test
   def test_simple_string_manipulation
     parser = Parsec::Parsec
     assert_equal(11, parser.eval_equation('length("test string")'))
-    assert_equal('TEST STRING', parser.eval_equation('toupper("test string")'))
-    assert_equal('test string', parser.eval_equation('tolower("TEST STRING")'))
-    assert_equal('Hello World', parser.eval_equation('concat("Hello ", "World")'))
-    assert_equal('Hello World', parser.eval_equation('concat("", "Hello World")'))
-    assert_equal('Hello World', parser.eval_equation('concat("Hello World", "")'))
-    assert_equal('tes t "str \" " ing equa  "   tion', parser.eval_equation('concat(concat("tes t", " \\"str \\\\\" \\" ing "),string("equa  \\"   tion"))'))
+    assert_equal('"TEST STRING"', parser.eval_equation('toupper("test string")'))
+    assert_equal('"test string"', parser.eval_equation('tolower("TEST STRING")'))
+    assert_equal('"Hello World"', parser.eval_equation('concat("Hello ", "World")'))
+    assert_equal('"Hello World"', parser.eval_equation('concat("", "Hello World")'))
+    assert_equal('"Hello World"', parser.eval_equation('concat("Hello World", "")'))
+    assert_equal('"tes t "str \" " ing equa  "   tion"', parser.eval_equation('concat(concat("tes t", " \\"str \\\\\" \\" ing "),string("equa  \\"   tion"))'))
     assert_equal(5, parser.eval_equation('str2number("5")'))
     assert_equal(5, parser.eval_equation('number("5")'))
-    assert_equal('Hello', parser.eval_equation('left("Hello World", 5)'))
-    assert_equal('World', parser.eval_equation('right("Hello World", 5)'))
-    assert_equal('<a href="http://foo.bar">Title</a>', parser.eval_equation('link("Title", "http://foo.bar")'))
-    assert_equal('<a href="#">Title</a>', parser.eval_equation('link("Title", "#")'))
-    assert_equal('<a href="/test">Test title</a>', parser.eval_equation('link("Test title", "/test")'))
-    assert_equal('<a href="/test" download="testFileName">Test title</a>', parser.eval_equation('link("Test title", "/test", "testFileName")'))
+    assert_equal('"Hello"', parser.eval_equation('left("Hello World", 5)'))
+    assert_equal('"World"', parser.eval_equation('right("Hello World", 5)'))
+    assert_equal('"<a href="http://foo.bar">Title</a>"', parser.eval_equation('link("Title", "http://foo.bar")'))
+    assert_equal('"<a href="#">Title</a>"', parser.eval_equation('link("Title", "#")'))
+    assert_equal('"<a href="/test">Test title</a>"', parser.eval_equation('link("Test title", "/test")'))
+    assert_equal('"<a href="/test" download="testFileName">Test title</a>"', parser.eval_equation('link("Test title", "/test", "testFileName")'))
     assert_equal(true, parser.eval_equation('contains("Hello World", "orld")'))
     assert_equal(true, parser.eval_equation('contains("One Flew Over The Cuckoo\'s", "koo")'))
     assert_equal(false, parser.eval_equation('contains("Hello World", "Worlds")'))
@@ -74,7 +74,7 @@ class TestParsec < Minitest::Test
     assert_equal(false, parser.eval_equation('contains("1234567", "789")'))
     assert_equal(true, parser.eval_equation('contains("2019-01-01T:08:30", "2019-01-01")'))
     assert_equal(false, parser.eval_equation('contains("2019-01-01T:08:30", "2021-01-01")'))
-    assert_equal('Maçã', parser.eval_equation('"Maçã"'))
+    assert_equal('"Maçã"', parser.eval_equation('"Maçã"'))
     assert_raises(SyntaxError) { parser.eval_equation('contains(1234567, "789")') }
     assert_raises(SyntaxError) { parser.eval_equation('contains("hello", 2.2)') }
     assert_raises(SyntaxError) { parser.eval_equation_with_type('link()') }
@@ -86,21 +86,21 @@ class TestParsec < Minitest::Test
 
   def test_complex_string_manipulation
     parser = Parsec::Parsec
-    assert_equal('string with quote"', parser.eval_equation('"string with quote\""'))
-    assert_equal('HELLO WORLD', parser.eval_equation('toupper(concat("hello ", "world"))'))
-    assert_equal('test lowercase', parser.eval_equation('tolower("TEST LOWERCASE")'))
-    assert_equal('Hello', parser.eval_equation('left("Hello World", 5)'))
-    assert_equal('World', parser.eval_equation('right("Hello World", 5)'))
-    assert_equal('Hello World', parser.eval_equation('right("Hello World", 20)'))
+    assert_equal('"string with quote""', parser.eval_equation('"string with quote\""'))
+    assert_equal('"HELLO WORLD"', parser.eval_equation('toupper(concat("hello ", "world"))'))
+    assert_equal('"test lowercase"', parser.eval_equation('tolower("TEST LOWERCASE")'))
+    assert_equal('"Hello"', parser.eval_equation('left("Hello World", 5)'))
+    assert_equal('"World"', parser.eval_equation('right("Hello World", 5)'))
+    assert_equal('"Hello World"', parser.eval_equation('right("Hello World", 20)'))
   end
 
   def test_general_equations
     parsec = Parsec::Parsec
     assert_equal(1, parsec.eval_equation('((0.09/1.0)+2.58)-1.67'))
-    assert_equal(40.6853, parsec.eval_equation('10^log(3+2)'))
+    assert_equal(40.6853365119738, parsec.eval_equation('10^log(3+2)'))
     assert_equal(1, parsec.eval_equation('log(e)'))
     assert_equal(2, parsec.eval_equation('2^5^0'))
-    assert_equal('yes', parsec.eval_equation('5 > 3 ? "yes" : "no"'))
+    assert_equal('"yes"', parsec.eval_equation('5 > 3 ? "yes" : "no"'))
     assert_equal(1, parsec.eval_equation('"this" == "this" ? 1 : 0'))
     assert_equal(9.9812, parsec.eval_equation('sqrt(9)+cbrt(8)+abs(-4.9812)'))
     assert_equal(3_628_680, parsec.send(:eval_equation, '10! - 5! * -(-1)'))
@@ -108,8 +108,8 @@ class TestParsec < Minitest::Test
     assert_equal(0.55, parsec.eval_equation('avg(1,2,3,4,5,6,7,8,9,10) / 10'))
     assert_equal(5, parsec.eval_equation('round(4.62)'))
     assert_equal(4.63, parsec.eval_equation('round_decimal(4.625, 2)'))
-    assert_equal('5', parsec.eval_equation('string(5)'))
-    assert_equal('5.123', parsec.eval_equation('string(5.123)'))
+    assert_equal('"5"', parsec.eval_equation('string(5)'))
+    assert_equal('"5.123"', parsec.eval_equation('string(5.123)'))
   end
 
   def test_newlines_remotion
@@ -127,7 +127,7 @@ class TestParsec < Minitest::Test
   def test_validate_syntax
     parsec = Parsec::Parsec
     refute_equal(true, parsec.validate_syntax('((0.09/1.0)+2.58)-1.6+'))
-    assert_equal('Missing parenthesis.', parsec.validate_syntax('(0.09/1.0'))
+    assert_equal('"Missing parenthesis."', parsec.validate_syntax('(0.09/1.0'))
   end
 
   def test_validate_syntax!
@@ -139,7 +139,7 @@ class TestParsec < Minitest::Test
   def test_date_functions
     parsec = Parsec::Parsec
     assert_equal(Date.today, Date.parse(parsec.eval_equation('current_date()')))
-    assert_match(/^\d{4}-\d{2}-\d{2}$/, parsec.eval_equation('current_date()'))
+    assert_match(/^"\d{4}-\d{2}-\d{2}"$/, parsec.eval_equation('current_date()'))
     assert_equal(364, parsec.eval_equation('daysdiff("2018-01-01", "2018-12-31")'))
     assert_equal(365, parsec.eval_equation('daysdiff("2016-01-01", "2016-12-31")'))
     assert_equal(365, parsec.eval_equation('daysdiff("2000-01-01", "2000-12-31")'))
@@ -178,17 +178,17 @@ class TestParsec < Minitest::Test
     parsec = Parsec::Parsec
 
     # With Dates
-    assert_equal('2019-01-01', parsec.eval_equation('add_days("2019-01-01", 0)'))
-    assert_equal('2019-01-02', parsec.eval_equation('add_days("2019-01-01", 1)'))
-    assert_equal('2018-12-31', parsec.eval_equation('add_days("2019-01-01", -1)'))
-    assert_equal('2019-01-04', parsec.eval_equation('add_days("2019-01-01", 3)'))
+    assert_equal('"2019-01-01"', parsec.eval_equation('add_days("2019-01-01", 0)'))
+    assert_equal('"2019-01-02"', parsec.eval_equation('add_days("2019-01-01", 1)'))
+    assert_equal('"2018-12-31"', parsec.eval_equation('add_days("2019-01-01", -1)'))
+    assert_equal('"2019-01-04"', parsec.eval_equation('add_days("2019-01-01", 3)'))
 
     # # With DateTimes
-    assert_equal('2019-01-01T08:30', parsec.eval_equation('add_days("2019-01-01T08:30", 0)'))
-    assert_equal('2019-02-01T12:30', parsec.eval_equation('add_days("2019-01-01T12:30", 31)'))
-    assert_equal('2019-01-02T15:30', parsec.eval_equation('add_days("2019-01-01T15:30", 1)'))
-    assert_equal('2019-01-02T20:30', parsec.eval_equation('add_days("2019-01-01T08:30", 1.5)'))
-    assert_equal('2018-12-31T08:30', parsec.eval_equation('add_days("2019-01-01T08:30", -1)'))
+    assert_equal('"2019-01-01T08:30"', parsec.eval_equation('add_days("2019-01-01T08:30", 0)'))
+    assert_equal('"2019-02-01T12:30"', parsec.eval_equation('add_days("2019-01-01T12:30", 31)'))
+    assert_equal('"2019-01-02T15:30"', parsec.eval_equation('add_days("2019-01-01T15:30", 1)'))
+    assert_equal('"2019-01-02T20:30"', parsec.eval_equation('add_days("2019-01-01T08:30", 1.5)'))
+    assert_equal('"2018-12-31T08:30"', parsec.eval_equation('add_days("2019-01-01T08:30", -1)'))
 
     # With Errors
     assert_raises(SyntaxError) { parsec.eval_equation_with_type('add_days("2019-01-33", 0)') }
@@ -200,25 +200,25 @@ class TestParsec < Minitest::Test
 
   def test_mask
     parsec = Parsec::Parsec
-    assert_equal('123-456', parsec.eval_equation('mask("000-000", 123456)'))
-    assert_equal('00014', parsec.eval_equation('mask("00000", 14)'))
-    assert_equal('000 14', parsec.eval_equation('mask("000 00", 14)'))
-    assert_equal('#123', parsec.eval_equation('concat("#", mask("000", 123))'))
-    assert_equal('12345', parsec.eval_equation('mask("0000", 12345)'))
-    assert_equal('123 45', parsec.eval_equation('mask("00 00", 12345)'))
-    assert_equal('3-5591-1801', parsec.eval_equation('mask("0-0000-0000", 355911801)'))
-    assert_equal('35-5591-1801', parsec.eval_equation('mask("00-0000-0000", 3555911801)'))
-    assert_equal('12-1234-1234-1234', parsec.eval_equation('mask("00-0000-0000-0000", 12123412341234)'))
-    assert_equal('1-1234-1234-1234-1234', parsec.eval_equation('mask("0-0000-0000-0000-0000", 11234123412341234)'))
+    assert_equal('"123-456"', parsec.eval_equation('mask("000-000", 123456)'))
+    assert_equal('"00014"', parsec.eval_equation('mask("00000", 14)'))
+    assert_equal('"000 14"', parsec.eval_equation('mask("000 00", 14)'))
+    assert_equal('"#123"', parsec.eval_equation('concat("#", mask("000", 123))'))
+    assert_equal('"12345"', parsec.eval_equation('mask("0000", 12345)'))
+    assert_equal('"123 45"', parsec.eval_equation('mask("00 00", 12345)'))
+    assert_equal('"3-5591-1801"', parsec.eval_equation('mask("0-0000-0000", 355911801)'))
+    assert_equal('"35-5591-1801"', parsec.eval_equation('mask("00-0000-0000", 3555911801)'))
+    assert_equal('"12-1234-1234-1234"', parsec.eval_equation('mask("00-0000-0000-0000", 12123412341234)'))
+    assert_equal('"1-1234-1234-1234-1234"', parsec.eval_equation('mask("0-0000-0000-0000-0000", 11234123412341234)'))
   end
 
   def test_string_cast
     parsec = Parsec::Parsec
-    assert_equal('4', parsec.eval_equation('string(4)'))
-    assert_equal('4.5', parsec.eval_equation('string(4.5)'))
-    assert_equal('true', parsec.eval_equation('string(true)'))
-    assert_equal('false', parsec.eval_equation('string(false)'))
-    assert_equal('4', parsec.eval_equation('string("4")'))
+    assert_equal('"4"', parsec.eval_equation('string(4)'))
+    assert_equal('"4.5"', parsec.eval_equation('string(4.5)'))
+    assert_equal('"true"', parsec.eval_equation('string(true)'))
+    assert_equal('"false"', parsec.eval_equation('string(false)'))
+    assert_equal('"4"', parsec.eval_equation('string("4")'))
   end
 
   def test_number_cast
@@ -238,8 +238,8 @@ class TestParsec < Minitest::Test
     assert_equal(1, parsec.eval_equation('default_value(NULL, 1)'))
     assert_equal(10.4, parsec.eval_equation('default_value(10.4, 1.01)'))
     assert_equal(1.01, parsec.eval_equation('default_value(NULL, 1.01)'))
-    assert_equal('filled', parsec.eval_equation('default_value("filled", "default")'))
-    assert_equal('default', parsec.eval_equation('default_value(NULL, "default")'))
+    assert_equal('"filled"', parsec.eval_equation('default_value("filled", "default")'))
+    assert_equal('"default"', parsec.eval_equation('default_value(NULL, "default")'))
     assert_equal(false, parsec.eval_equation('default_value(false, true)'))
     assert_equal(true, parsec.eval_equation('default_value(NULL, true)'))
 
@@ -265,11 +265,11 @@ class TestParsec < Minitest::Test
     assert_equal({ value: 362_880_0, type: :int }, parsec.eval_equation_with_type('10!'))
     equation_date = 'daysdiff("2018-01-01", "2017-12-31")'
     assert_equal({ value: 1, type: :int }, parsec.eval_equation_with_type(equation_date))
-    assert_equal({ value: 40.6853, type: :float }, parsec.eval_equation_with_type('10^log(3+2)'))
+    assert_equal({ value: 40.6853365119738, type: :float }, parsec.eval_equation_with_type('10^log(3+2)'))
     assert_equal({ value: 5.1, type: :float }, parsec.eval_equation_with_type('number("5.1")'))
     equation_if = '4 > 2 ? "bigger" : "smaller"'
-    assert_equal({ value: 'bigger', type: :string }, parsec.eval_equation_with_type(equation_if))
-    assert_equal({ value: '5.123', type: :string }, parsec.eval_equation_with_type('string(5.123)'))
+    assert_equal({ value: '"bigger"', type: :string }, parsec.eval_equation_with_type(equation_if))
+    assert_equal({ value: '"5.123"', type: :string }, parsec.eval_equation_with_type('string(5.123)'))
     equation_boolean = '2 == 2 ? true : false'
     assert_equal({ value: true, type: :boolean }, parsec.eval_equation_with_type(equation_boolean))
     equation_boolean = '(3==3) and (3!=3)'


### PR DESCRIPTION
This PR updates the equations-parser version, wich now converts decimals to string with a better precision.


## Before
![image](https://user-images.githubusercontent.com/5000206/203446215-061be54a-84de-4293-b6f6-069fa26aa229.png)



## After
![image](https://user-images.githubusercontent.com/5000206/203418784-1b93b68f-e62b-45aa-9019-036cf620ccc2.png)
